### PR TITLE
ghcr.io/ansys/pymechanical/mechanical:v23.2.0 to ghcr.io/ansys/mechanical:23.2.0 changes

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,8 +15,8 @@ env:
   MAIN_PYTHON_VERSION: '3.10'
   PYMECHANICAL_PORT: 10000  # default won't work on GitHub runners
   PYMECHANICAL_START_INSTANCE: FALSE
-  DOCKER_PACKAGE: ghcr.io/ansys/pymechanical/mechanical
-  DOCKER_IMAGE_VERSION: v23.2.0
+  DOCKER_PACKAGE: ghcr.io/ansys/mechanical
+  DOCKER_IMAGE_VERSION: 23.2.0
   DOCKER_MECH_CONTAINER_NAME: mechanical
   PACKAGE_NAME: ansys-mechanical-core
   PACKAGE_NAMESPACE: ansys.mechanical.core


### PR DESCRIPTION
change the ci/cd to use

ghcr.io/ansys/mechanical:23.2.0

instead of

ghcr.io/ansys/pymechanical/mechanical:v23.2.0